### PR TITLE
use OTel with Orchestrion

### DIFF
--- a/handlers/hello_handler.go
+++ b/handlers/hello_handler.go
@@ -23,7 +23,7 @@ type HelloResponse struct {
 	SystemInfo *SystemStats `json:"system_info"`
 }
 
-func HelloHandler(w http.ResponseWriter, _ *http.Request) {
+func HelloHandler(w http.ResponseWriter, r *http.Request) {
 	// Give a 1/10 chance for the handler to respond with an error
 	instrumentation := InstrumentationMethod
 	if rand.IntN(10) == 0 {

--- a/main.go
+++ b/main.go
@@ -10,30 +10,33 @@ import (
 func main() {
 	handlers.SetupEnv()
 
+	var handler http.Handler
 	if handlers.InstrumentationMethod == "manual" {
-		ManualInstrument()
-		return
+		handler = ManualInstrument()
+	} else {
+		handler = DefaultInstrumentation()
 	}
-	DefaultInstrumentation()
-}
-
-// Create a simple /hello endpoint. We can also use this as the entry
-// point for autoinstrumenting using Orchestrion + OTel
-func DefaultInstrumentation() {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/hello", handlers.HelloHandler)
 
 	server := &http.Server{
 		Addr:    ":8080",
-		Handler: mux,
+		Handler: handler,
 	}
 
 	server.ListenAndServe()
 }
 
+// Create a simple /hello endpoint. We can also use this as the entry
+// point for autoinstrumenting using Orchestrion + OTel
+func DefaultInstrumentation() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", handlers.HelloHandler)
+
+	return mux
+}
+
 // Manually instrument our http call using the OTel SDK
 // Code inspired by https://opentelemetry.io/docs/languages/go/getting-started
-func ManualInstrument() {
+func ManualInstrument() http.Handler {
 	mux := http.NewServeMux()
 
 	handleFunc := func(pattern string, handlerFunc func(http.ResponseWriter, *http.Request)) {
@@ -45,10 +48,5 @@ func ManualInstrument() {
 
 	handler := otelhttp.NewHandler(mux, "/")
 
-	server := &http.Server{
-		Addr:    ":8080",
-		Handler: handler,
-	}
-
-	server.ListenAndServe()
+	return handler
 }

--- a/orchestrion.yml
+++ b/orchestrion.yml
@@ -9,6 +9,6 @@ aspects:
     join-point:
       all-of:
         - package-name: main
-        - function-call: DefaultInstrumentation
+        - function-call: github.com/hannahkm/gopherconus-2025.DefaultInstrumentation
     advice:
       - replace-function: github.com/hannahkm/gopherconus-2025.ManualInstrument

--- a/orchestrion.yml
+++ b/orchestrion.yml
@@ -11,4 +11,4 @@ aspects:
         - package-name: main
         - function-call: DefaultInstrumentation
     advice:
-      - replace-function: github.com/hannahkm/gopherconus-2025.ManualInstrumentation
+      - replace-function: github.com/hannahkm/gopherconus-2025.ManualInstrument

--- a/orchestrion.yml
+++ b/orchestrion.yml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://datadoghq.dev/orchestrion/schema.json
+meta:
+  name: otel-orchestrion
+  description: Enables running the OTel SDK under the hood with Orchestrion
+
+aspects:
+  - id: Error Tracking
+    join-point:
+      all-of:
+        - package-name: main
+        - function-call: DefaultInstrumentation
+    advice:
+      - replace-function: github.com/hannahkm/gopherconus-2025.ManualInstrumentation

--- a/orchestrion.yml
+++ b/orchestrion.yml
@@ -5,10 +5,47 @@ meta:
   description: Enables running the OTel SDK under the hood with Orchestrion
 
 aspects:
-  - id: Error Tracking
+  - id: Create OTel handlers
     join-point:
-      all-of:
-        - package-name: main
-        - function-call: github.com/hannahkm/gopherconus-2025.DefaultInstrumentation
+      function-body: 
+        function:
+          - name: DefaultInstrumentation
     advice:
-      - replace-function: github.com/hannahkm/gopherconus-2025.ManualInstrument
+      prepend-statements:
+        imports:
+          otelhttp: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+          http: net/http
+          handlers: github.com/hannahkm/gopherconus-2025/handlers
+        template: |-
+          {{ $ret := .Function.ResultThatImplements "net/http.Handler" }}
+          {{ with $ret }}
+            defer func() {
+              mux := http.NewServeMux()
+              handleFunc := func(pattern string, handlerFunc func(http.ResponseWriter, *http.Request)) {
+                // Configure the "http.route" for the HTTP instrumentation.
+                handler := otelhttp.WithRouteTag(pattern, http.HandlerFunc(handlerFunc))
+                mux.Handle(pattern, handler)
+              }
+              handleFunc("/hello", handlers.HelloHandler)
+
+              {{ $ret }} = otelhttp.NewHandler(mux, "/")
+            }()
+          {{- end -}}
+  - id: Start OTel spans
+    join-point:
+      function-body: 
+        function:
+          - name: HelloHandler
+    advice:
+      prepend-statements:
+        imports: 
+          http: net/http
+          otel: go.opentelemetry.io/otel
+        template: |-
+          {{ $r := .Function.ArgumentOfType "*http.Request" -}}
+          {{ with $r}}
+            tracer := otel.Tracer("orchestrion")
+            ctx, span := tracer.Start({{ $r }}.Context(), "hello")
+            defer span.End()
+            *{{ $r }} = *{{ $r }}.WithContext(ctx)
+          {{- end -}}


### PR DESCRIPTION
enable apples to apples comparisons. Since we're using the OTel SDK for manual instrumentation, we also want to use OTel instead of dd-trace-go when instrumenting with Orchestrion