### PR TITLE
feat: send traces to datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Running any load test will start up Grafana at `localhost:3000` where you can fi
 ![system info](./example_img/sample_dashboard1.png)
 ![testing info](./example_img/sample_dashboard2.png)
 
+### Viewing Data
+
+By default, metrics and traces will be sent to Datadog. Remember to set your `DD_API_KEY` in `.env` to ensure traces are sent properly. If you are unable to use Datadog, you may instead send metrics and traces to Grafana using InfluxDB by making the following edits:
+
+1. In `otel-collector-config.yaml`, comment out the Datadog exporter
+2. In `otel-collector-config.yaml`, set the exporter to `[otlp]` for traces and to `[prometheus]` for metrics.
+3. In `loadtest.sh`, uncomment out the lines for InfluxDB and comment out the lines for OpenTelemetry.
+
+The Grafana dashboard will be hosted at `localhost:3000`.
+
 ## Read More
 
 Interested in (auto) instrumentation? Here are a couple of blog posts and articles that can help you get started!

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -433,10 +433,15 @@ for INSTRUMENTATION in "${TESTS_TO_RUN[@]}"; do
 	# Run load tests
 	echo "🚀 Starting k6 load test..."
 
-	# Build InfluxDB URL for the xk6-influxdb extension
-	INFLUXDB_URL="http://localhost:8086?bucket=${K6_INFLUXDB_BUCKET}&organization=${K6_INFLUXDB_ORGANIZATION}&token=${K6_INFLUXDB_TOKEN}"
-	echo "Running k6 with InfluxDB extension..."
-	"$K6_BINARY" run --out "xk6-influxdb=${INFLUXDB_URL}" k6_loadtesting.js
+	# If you would prefer to use Grafana with InfluxDB, uncomment the following lines instead:
+	## Build InfluxDB URL for the xk6-influxdb extension
+	# INFLUXDB_URL="http://localhost:8086?bucket=${K6_INFLUXDB_BUCKET}&organization=${K6_INFLUXDB_ORGANIZATION}&token=${K6_INFLUXDB_TOKEN}"
+	# echo "Running k6 with InfluxDB extension..."
+	# "$K6_BINARY" run --out "xk6-influxdb=${INFLUXDB_URL}" k6_loadtesting.js
+
+	# And if you are using Grafana with InfluxDB, be sure to comment out these two lines
+	echo "Running k6 with OpenTelemetry extension..."
+	K6_OTEL_GRPC_EXPORTER_ENDPOINT=localhost:4317 K6_OTEL_GRPC_EXPORTER_INSECURE=true K6_OTEL_METRIC_PREFIX=k6_ "$K6_BINARY" run -o experimental-opentelemetry k6_loadtesting.js
 
 	# Stop eBPF services if they were started for this test
 	if [[ "$INSTRUMENTATION" == "ebpf" && "$EBPF_SERVICES_STARTED" == "true" ]]; then

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -31,7 +31,7 @@ exporters:
     endpoint: jaeger:4317
     tls:
       insecure: true
-  datadog:  # Uncomment these lines and update pipeline below when DD_API_KEY is available
+  datadog:  # Comment out these lines and update pipeline below if DD_API_KEY is not available
     api:
       site: datadoghq.com
       key: ${DD_API_KEY}
@@ -78,11 +78,11 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch, resource]
-      exporters: [otlp, datadog, spanmetrics] # Change to [otlp, datadog, spanmetrics] when enabling Datadog above
+      exporters: [otlp, datadog, spanmetrics] # Change to [otlp] when disabling Datadog
     metrics:
       receivers: [otlp]
       processors: [batch, resource]
-      exporters: [prometheus]
+      exporters: [prometheus, datadog] # Change to [prometheus] when disabling Datadog
     metrics/spanmetrics:
       receivers: [spanmetrics]
       exporters: [prometheus]

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -78,7 +78,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch, resource]
-      exporters: [otlp, datadog] # Change to [otlp, datadog] when enabling Datadog above
+      exporters: [otlp, datadog, spanmetrics] # Change to [otlp, datadog, spanmetrics] when enabling Datadog above
     metrics:
       receivers: [otlp]
       processors: [batch, resource]

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -31,10 +31,10 @@ exporters:
     endpoint: jaeger:4317
     tls:
       insecure: true
-  # datadog:  # Uncomment these lines and update pipeline below when DD_API_KEY is available
-  #   api:
-  #     site: datadoghq.com
-  #     key: ${DD_API_KEY}
+  datadog:  # Uncomment these lines and update pipeline below when DD_API_KEY is available
+    api:
+      site: datadoghq.com
+      key: ${DD_API_KEY}
 
 connectors:
   spanmetrics:
@@ -78,7 +78,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch, resource]
-      exporters: [otlp, spanmetrics] # Change to [otlp, datadog] when enabling Datadog above
+      exporters: [otlp, datadog] # Change to [otlp, datadog] when enabling Datadog above
     metrics:
       receivers: [otlp]
       processors: [batch, resource]


### PR DESCRIPTION
by default, now send metrics and traces to datadog. added instructions for using Grafana with InfluxDB if needed.